### PR TITLE
Remove a bunch of stuff from exports

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NaiveNASlib"
 uuid = "bd45eb3e-47ce-54bd-9eaf-e86c5f900853"
-version = "1.1.1"
+version = "2.0.0"
 
 [deps]
 Cbc = "9961bab8-2fa3-5c5a-9d89-47fab24efd76"
@@ -11,8 +11,8 @@ MetaGraphs = "626554b9-1ddb-594c-aa3c-2596fe9399a5"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-Cbc = "0.6.3"
-JuMP = "0.19.2, 0.20"
+Cbc = "0.6"
+JuMP = "0.19.2, 0.20, 0.21"
 LightGraphs = "1.2.0"
 MetaGraphs = "0.6.4"
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 Cbc = "0.6"
-JuMP = "0.19.2, 0.20, 0.21"
+JuMP = "0.21"
 LightGraphs = "1.2.0"
 MetaGraphs = "0.6.4"
 julia = "1"

--- a/src/NaiveNASlib.jl
+++ b/src/NaiveNASlib.jl
@@ -6,26 +6,26 @@ using Logging
 
 import JuMP
 import JuMP: @variable, @constraint, @objective, @expression, MOI, MOI.INFEASIBLE, MOI.FEASIBLE_POINT
-using Cbc
+import Cbc
 
 #Interface
-export AbstractVertex, AbstractMutationVertex, MutationOp, MutationState
+export AbstractVertex, AbstractMutationVertex
 
 # Vertex
 export InputVertex, CompVertex, inputs, outputs
 
 # Information strings
-export infostr, name, RawInfoStr, NameInfoStr, InputsInfoStr, OutputsInfoStr, SizeInfoStr, MutationTraitInfoStr, ComposedInfoStr, NameAndInputsInfoStr, NinInfoStr, NoutInfoStr, NameAndIOInfoStr, FullInfoStr,MutationSizeTraitInfoStr
+export infostr, name, RawInfoStr, NameInfoStr, InputsInfoStr, OutputsInfoStr, SizeInfoStr, MutationTraitInfoStr, ComposedInfoStr, NameAndInputsInfoStr, NinInfoStr, NoutInfoStr, NameAndIOInfoStr, FullInfoStr, MutationSizeTraitInfoStr
 
 # Computation graph
-export CompGraph, SizeDiGraph, output!,flatten, nv, vertices
+export CompGraph, SizeDiGraph, output!, ancestors, nv, vertices
 
 # Mutation operations
 #State
-export InvSize, IoSize, InvIndices, IoIndices, NoOp, IoChange, nin, nout, Δnin, Δnout, clone, op, in_inds, out_inds, nin_org, nout_org
+export nin, nout, Δnin, Δnout, clone, in_inds, out_inds, nin_org, nout_org
 
 # Mutation vertex
-export base, InputSizeVertex, OutputsVertex, MutationVertex
+export InputSizeVertex, MutationVertex
 
 # Mutation traits
 export trait, MutationTrait, DecoratingTrait, NamedTrait, Immutable, MutationSizeTrait, SizeAbsorb, SizeStack, SizeInvariant, SizeChangeLogger, SizeChangeValidation
@@ -48,7 +48,7 @@ export AbstractAlignSizeStrategy, IncreaseSmaller, DecreaseBigger, AlignSizeBoth
 export AbstractConnectStrategy, ConnectAll, ConnectNone
 
 # apply mutation
-export mutate_inputs, mutate_outputs, apply_mutation
+export apply_mutation
 
 #sugar
 export inputvertex, vertex, immutablevertex, absorbvertex, invariantvertex, conc, VertexConf, traitconf, mutationconf, outwrapconf

--- a/src/compgraph.jl
+++ b/src/compgraph.jl
@@ -77,14 +77,14 @@ end
 
 Return g as a SimpleDiGraph.
 """
-LightGraphs.SimpleDiGraph(g::CompGraph) = SimpleDiGraph(mapfoldl(v -> flatten(v), (vs1, vs2) -> unique(vcat(vs1, vs2)), g.outputs))
+LightGraphs.SimpleDiGraph(g::CompGraph) = SimpleDiGraph(mapfoldl(v -> ancestors(v), (vs1, vs2) -> unique(vcat(vs1, vs2)), g.outputs))
 
 """
     SimpleDiGraph(v::AbstractVertex)
 
 Return a SimpleDiGraph of all parents of v
 """
-LightGraphs.SimpleDiGraph(v::AbstractVertex)= SimpleDiGraph(flatten(v))
+LightGraphs.SimpleDiGraph(v::AbstractVertex)= SimpleDiGraph(ancestors(v))
 
 """
     SimpleDiGraph(vertices::AbstractArray{AbstractVertex,1})
@@ -108,23 +108,23 @@ LightGraphs.nv(g::CompGraph) = nv(SimpleDiGraph(g))
 
 
 """
-    flatten(v::AbstractVertex)
+    ancestors(v::AbstractVertex)
 
-Return an array of all input parents of v
+Return an array of all input ancestors of v
 
 # Examples
 ```julia-repl
-julia> flatten(CompVertex(+, InputVertex.(1:2)...))
+julia> ancestors(CompVertex(+, InputVertex.(1:2)...))
 3-element Array{AbstractVertex,1}:
  InputVertex(1)
  InputVertex(2)
  CompVertex(+, [InputVertex(1), InputVertex(2)])
 """
-function flatten(v::AbstractVertex, vertices::Vector{AbstractVertex} = Vector{AbstractVertex}(), visited::Vector{AbstractVertex} = Vector{AbstractVertex}())
+function ancestors(v::AbstractVertex, vertices::Vector{AbstractVertex} = Vector{AbstractVertex}(), visited::Vector{AbstractVertex} = Vector{AbstractVertex}())
     v in vertices && return vertices
     if !(v in visited)
         push!(visited, v)
-        foreach(iv -> flatten(iv, vertices), inputs(v))
+        foreach(iv -> ancestors(iv, vertices), inputs(v))
     end
     push!(vertices, v)
     return vertices
@@ -153,7 +153,7 @@ julia> vertices(graph)
  CompVertex(*), inputs=[CompVertex(+), InputVertex(2)]
 ```
 """
-LightGraphs.vertices(g::CompGraph) = unique(mapfoldl(flatten, vcat, g.outputs))
+LightGraphs.vertices(g::CompGraph) = unique(mapfoldl(ancestors, vcat, g.outputs))
 
 """
     Base.copy(g::CompGraph, cf=clone)

--- a/src/mutation/graph.jl
+++ b/src/mutation/graph.jl
@@ -139,14 +139,14 @@ Edge weights denoted by the symbol `:size` represents the size of the output sen
 Note that the order of the input edges to a vertex matters (in case there are more than one) and is not encoded in `g`.
 Instead, use `indexin(vi, inputs(v))` to find the index (or indices if input multiple times) of `vi` in `inputs(v)`.
 """
-SizeDiGraph(cg::CompGraph) = SizeDiGraph(mapfoldl(v -> flatten(v), (vs1, vs2) -> unique(vcat(vs1, vs2)), cg.outputs))
+SizeDiGraph(cg::CompGraph) = SizeDiGraph(mapfoldl(v -> ancestors(v), (vs1, vs2) -> unique(vcat(vs1, vs2)), cg.outputs))
 
 """
     SizeDiGraph(v::AbstractVertex)
 
 Return a SizeDiGraph of all parents of v
 """
-SizeDiGraph(v::AbstractVertex)= SizeDiGraph(flatten(v))
+SizeDiGraph(v::AbstractVertex)= SizeDiGraph(ancestors(v))
 
 """
     SizeDiGraph(vertices::AbstractArray{AbstractVertex,1})

--- a/src/mutation/select.jl
+++ b/src/mutation/select.jl
@@ -245,7 +245,7 @@ end
 
 accept(::AbstractJuMPSelectionStrategy, model::JuMP.Model) = JuMP.termination_status(model) != MOI.INFEASIBLE && JuMP.primal_status(model) == MOI.FEASIBLE_POINT # Beware: primal_status seems unreliable for Cbc. See MathOptInterface issue #822
 
-selectmodel(::AbstractJuMPSelectionStrategy, v, values) = JuMP.Model(JuMP.with_optimizer(Cbc.Optimizer, loglevel=0))
+selectmodel(::AbstractJuMPSelectionStrategy, v, values) = JuMP.Model(JuMP.optimizer_with_attributes(Cbc.Optimizer, "loglevel"=>0))
 
 # First dispatch on traits to sort out things like immutable vertices
 vertexconstraints!(v::AbstractVertex, s::AbstractJuMPSelectionStrategy, data) = vertexconstraints!(trait(v), v, s, data)

--- a/src/mutation/size.jl
+++ b/src/mutation/size.jl
@@ -514,7 +514,7 @@ end
 
 Return a `JuMP.Model` for executing strategy `s` on `vertices`.
 """
-sizemodel(s::AbstractJuMPΔSizeStrategy, vertices) = JuMP.Model(JuMP.with_optimizer(Cbc.Optimizer, loglevel=0))
+sizemodel(s::AbstractJuMPΔSizeStrategy, vertices) = JuMP.Model(JuMP.optimizer_with_attributes(Cbc.Optimizer, "loglevel"=>0))
 
 # Just a shortcut for broadcasting on dicts
 getall(d::Dict, ks, deffun=() -> missing) = get.(deffun, [d], ks)

--- a/test/compgraph.jl
+++ b/test/compgraph.jl
@@ -1,7 +1,9 @@
-import NaiveNASlib:CompGraph, CompVertex, InputVertex, SimpleDiGraph
-import LightGraphs:adjacency_matrix,is_cyclic
 
 @testset "Computation graph tests" begin
+
+    import NaiveNASlib:CompGraph, CompVertex, InputVertex, SimpleDiGraph, op, IoIndices, IoChange
+    import LightGraphs:adjacency_matrix,is_cyclic
+
 
     @testset "Scalar computation graphs" begin
 
@@ -95,11 +97,11 @@ import LightGraphs:adjacency_matrix,is_cyclic
         testop(v::MutationVertex) = testop(trait(v), v)
         function testop(::MutationTrait, v) end
         testop(::SizeAbsorb, v) = @test typeof(op(v)) == IoChange
-        foreach(testop, mapreduce(flatten, vcat, graph.outputs))
+        foreach(testop, mapreduce(ancestors, vcat, graph.outputs))
 
         # But new graph shall use IoIndices
         testop(::SizeAbsorb, v) = @test typeof(op(v)) == IoIndices
-        foreach(testop, mapreduce(flatten, vcat, graph_inds.outputs))
+        foreach(testop, mapreduce(ancestors, vcat, graph_inds.outputs))
     end
 
     @testset "Graph add trait" begin

--- a/test/mutation/op.jl
+++ b/test/mutation/op.jl
@@ -1,7 +1,7 @@
 
 @testset "Vertex mutation operations" begin
 
-    import NaiveNASlib:reset_in!, reset_out!, reset!, IoIndices, MutationState
+    import NaiveNASlib:reset_in!, reset_out!, reset!, IoIndices, IoSize, MutationState
     import InteractiveUtils:subtypes
 
 

--- a/test/mutation/op.jl
+++ b/test/mutation/op.jl
@@ -1,8 +1,9 @@
-import NaiveNASlib
-import NaiveNASlib:reset_in!, reset_out!, reset!
-import InteractiveUtils:subtypes
 
 @testset "Vertex mutation operations" begin
+
+    import NaiveNASlib:reset_in!, reset_out!, reset!, IoIndices, MutationState
+    import InteractiveUtils:subtypes
+
 
     expectedtype(t::Type{<:MutationOp}) = Integer
     expectedtype(t::Type{IoIndices}) = AbstractArray{<:Integer,1}

--- a/test/mutation/structure.jl
+++ b/test/mutation/structure.jl
@@ -1,6 +1,8 @@
 
 @testset "Structure tests" begin
 
+    import NaiveNASlib: op
+
     #Helper functions
     nt(name) = t -> NamedTrait(t, name)
     tf(name) = t -> nt(name)(t)

--- a/test/mutation/sugar.jl
+++ b/test/mutation/sugar.jl
@@ -1,6 +1,8 @@
-import NaiveNASlib
 
 @testset "Sugar" begin
+
+    import NaiveNASlib: IoSize
+
 
     struct ScaleByTwo
         f

--- a/test/mutation/vertex.jl
+++ b/test/mutation/vertex.jl
@@ -1,8 +1,8 @@
-import NaiveNASlib
-import NaiveNASlib:OutputsVertex
-import InteractiveUtils:subtypes
 
 @testset "Mutation vertices" begin
+
+    import NaiveNASlib: InputVertex, InputSizeVertex, OutputsVertex, base, IoSize, NoOp
+    import InteractiveUtils: subtypes
 
     @testset "OutputsVertex" begin
         iv = OutputsVertex(InputVertex(1))

--- a/test/testutil.jl
+++ b/test/testutil.jl
@@ -1,3 +1,5 @@
+import NaiveNASlib: MutationOp
+
 
 function implementations(T::Type)
     return mapreduce(t -> isabstracttype(t) ? implementations(t) : t, vcat, subtypes(T), init=[])


### PR DESCRIPTION
Rename flatten to ancestors to avoid name conflict with Flux
Update JuMP and Cbc