### PR TITLE
Improve handling for some cases of structural misalignment

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NaiveNASlib"
 uuid = "bd45eb3e-47ce-54bd-9eaf-e86c5f900853"
-version = "1.2.2"
+version = "1.3.0"
 
 [deps]
 Cbc = "9961bab8-2fa3-5c5a-9d89-47fab24efd76"

--- a/src/NaiveNASlib.jl
+++ b/src/NaiveNASlib.jl
@@ -36,7 +36,7 @@ export minΔnoutfactor, minΔninfactor, minΔnoutfactor_only_for, minΔninfactor
 export AbstractΔSizeStrategy, AbstractJuMPΔSizeStrategy, ΔSizeFailError, ΔSizeFailNoOp, LogΔSizeExec, DefaultJuMPΔSizeStrategy, ΔNout, ΔNoutExact, ΔNoutRelaxed, ΔNin, ΔNinExact, ΔNinRelaxed, AlignNinToNout, Exact, Relaxed
 
 #Selection util
-export AbstractSelectionStrategy, LogSelection, LogSelectionFallback, SelectionFail, NoutRevert, SelectDirection, ApplyAfter, AbstractJuMPSelectionStrategy, DefaultJuMPSelectionStrategy, OutSelect, OutSelectExact, OutSelectRelaxed, Δoutputs, solve_outputs_selection
+export AbstractSelectionStrategy, LogSelection, LogSelectionFallback, SelectionFail, NoutRevert, SelectDirection, ApplyAfter, AbstractJuMPSelectionStrategy, DefaultJuMPSelectionStrategy, OutSelect, OutSelectExact, OutSelectRelaxed, TruncateInIndsToValid, Δoutputs, solve_outputs_selection
 
 # Connectivity mutation
 export remove!, RemoveStrategy, insert!, create_edge!, remove_edge!

--- a/src/NaiveNASlib.jl
+++ b/src/NaiveNASlib.jl
@@ -42,7 +42,7 @@ export AbstractSelectionStrategy, LogSelection, LogSelectionFallback, SelectionF
 export remove!, RemoveStrategy, insert!, create_edge!, remove_edge!
 
 # Align size strategies, e.g what to do with sizes of vertices connected to a removed vertex
-export AbstractAlignSizeStrategy, IncreaseSmaller, DecreaseBigger, AlignSizeBoth, ChangeNinOfOutputs, AdjustToCurrentSize, FailAlignSizeError, FailAlignSizeWarn, FailAlignSizeRevert, NoSizeChange, CheckAligned, CheckNoSizeCycle, CheckCreateEdgeNoSizeCycle, PostAlignJuMP, SelectOutputs, ApplyMutation, PostSelectOutputs, PostApplyMutation
+export AbstractAlignSizeStrategy, IncreaseSmaller, DecreaseBigger, AlignSizeBoth, ChangeNinOfOutputs, AdjustToCurrentSize, FailAlignSizeNoOp, FailAlignSizeError, FailAlignSizeWarn, FailAlignSizeRevert, NoSizeChange, CheckAligned, CheckNoSizeCycle, CheckCreateEdgeNoSizeCycle, PostAlignJuMP, SelectOutputs, ApplyMutation, PostSelectOutputs, PostApplyMutation
 
 # Connect strategies
 export AbstractConnectStrategy, ConnectAll, ConnectNone

--- a/src/mutation/apply.jl
+++ b/src/mutation/apply.jl
@@ -31,7 +31,8 @@ Supplied `kwargs` will be passed on to computation.
 """
 function apply_mutation(v::AbstractVertex; kwargs...) end
 function apply_mutation(v::MutationVertex; kwargs...)
-    mutate_inputs(v; kwargs...)
+    # Empty nin leads to stack overflow due to splatting below.
+    !isempty(nin(v)) && mutate_inputs(v; kwargs...)
     mutate_outputs(v; kwargs...)
 end
 apply_mutation(g::CompGraph; kwargs...) = apply_mutation.(vertices(g); kwargs...)

--- a/src/mutation/structure.jl
+++ b/src/mutation/structure.jl
@@ -44,6 +44,8 @@ end
     FailAlignSizeNoOp()
 
 Don't do any size change and return failure status.
+
+Note that this means that graphs will most likely be left corrupted state if used as a fallback.
 """
 struct FailAlignSizeNoOp <: AbstractAlignSizeStrategy end
 

--- a/src/mutation/structure.jl
+++ b/src/mutation/structure.jl
@@ -40,6 +40,14 @@ struct ChangeNinOfOutputs <: AbstractAlignSizeStrategy
 end
 
 """
+    FailAlignSizeNoOp <: AbstractAlignSizeStrategy
+    FailAlignSizeNoOp()
+
+Don't do any size change and return failure status.
+"""
+struct FailAlignSizeNoOp <: AbstractAlignSizeStrategy end
+
+"""
     FailAlignSizeError <: AbstractAlignSizeStrategy
     FailAlignSizeError()
 
@@ -273,12 +281,12 @@ Default strategy is to first set `nin==nout` for `v` and then connect all its `i
 to all its `outputs`.
 """
 function remove!(v::MutationVertex, strategy=RemoveStrategy())
-    prealignsizes(strategy.align, v, vx -> vx == v) || return
+    prealignsizes(strategy.align, v, vx -> vx == v) || return false
 
     remove!(v, inputs, outputs, strategy.reconnect)
     remove!(v, outputs, inputs, strategy.reconnect)
 
-    postalignsizes(strategy.align, v)
+    return postalignsizes(strategy.align, v)
 end
 
 ## Helper function to avoid code duplication. I don't expect this to be able to do
@@ -326,6 +334,7 @@ function prealignsizes(s::FailAlignSizeWarn, vin, vout, will_rm)
     return prealignsizes(s.andthen, vin, vout, will_rm)
 end
 prealignsizes(::FailAlignSizeRevert, vin, vout, will_rm) = false # No action needed?
+prealignsizes(::FailAlignSizeNoOp, vin, vout, will_rm) = false
 
 # Actual actions
 function prealignsizes(s::CheckAligned, vin, vout, will_rm)
@@ -430,6 +439,7 @@ postalignsizes(s::AbstractAlignSizeStrategy, v) = postalignsizes(s, v, v, missin
 postalignsizes(s::AbstractAlignSizeStrategy, vin, vout, pos) = true
 
 # Failure cases
+postalignsizes(::FailAlignSizeNoOp, vin, vout, pos) = false
 postalignsizes(::FailAlignSizeError, vin, vout, pos) = error("Could not align sizes of $(vin) and $(vout)!")
 function postalignsizes(s::FailAlignSizeWarn, vin, vout, pos)
     @warn s.msgfun(vin, vout)

--- a/test/mutation/apply.jl
+++ b/test/mutation/apply.jl
@@ -113,6 +113,20 @@
         @test mm3.W == [3 10 17; 5 12 19; 0 0 0; 0 0 0; 0 0 0]
     end
 
+    @testset "No apply to vertex with no inputs" begin
+        mmv1, mm1 = mcv(2, 4, inpt(2, "in"), "mmv1")
+        mmv2, mm2 = mcv(4, 3, mmv1, "mmv2")
+
+        w1pre = mm1.W
+        w2pre = mm2.W
+
+        remove_edge!(mmv1, mmv2)
+        apply_mutation.([mmv1, mmv2])
+
+        @test mm1.W == w1pre
+        @test mm2.W == w2pre
+    end
+
     @testset "Size only mutation" begin
         mutable struct SizeProbe
             nin

--- a/test/mutation/select.jl
+++ b/test/mutation/select.jl
@@ -548,6 +548,26 @@
         @test size(g(ones(Float32, 1,3))) == (1, nout(v4))
     end
 
+    @testset "TruncateInIndsToValid" begin
+        inpt = iv(3)
+        v1 = av(inpt, 3, "v1")
+        v2 = tv(v1, "v2")
+        v3 = av(v2, 2, "v3")
+
+        g = CompGraph(inpt, v2)
+        @test size(g(ones(Float32, 1,3))) == (1, nout(v2))
+
+        vnew = av(inpt, 7, "vnew")
+        create_edge!(vnew, v2;strategy=PostAlignJuMP())
+        @test nin_org(v2) == [3, 0] != [nout(v1), nout(vnew)]
+
+        Δoutputs(TruncateInIndsToValid(), g, v -> 1:nout_org(v))
+
+        @test out_inds(op(vnew)) == [4,5,6,7]
+        @test in_inds(op(v2)) == [[1,2,3,-1], [1,2,3,-1]]
+        @test out_inds(op(v2)) == [1,2,3,-1]
+    end
+
     @testset "CompConstraint" begin
 
         struct CompConstraint end

--- a/test/mutation/structure.jl
+++ b/test/mutation/structure.jl
@@ -14,6 +14,17 @@
     @testset "Edge mutation" begin
         @testset "Edge removal" begin
 
+            @testset "Fail noop" begin
+                v0 = inpt(3, "v0")
+                v1 = av(v0, 5, name="v1")
+                v2 = av(v1, 4, name="v2")
+
+                @test remove_edge!(v1, v2; strategy=FailAlignSizeNoOp()) == false
+
+                @test name.(inputs(v2)) == [name(v1)]
+                @test name.(outputs(v1)) == [name(v2)]
+            end
+
             @testset "Remove from absorbing" begin
                 v0 = inpt(3, "v0")
                 v1 = av(v0, 5, name="v1")
@@ -324,6 +335,17 @@
         end
 
         @testset "Edge addition" begin
+
+            @testset "Fail noop" begin
+                v0 = inpt(3, "v0")
+                v1 = av(v0, 5, name="v1")
+                v2 = av(v1, 4, name="v2")
+
+                @test create_edge!(v1, v2; strategy=FailAlignSizeNoOp()) == false
+
+                @test name.(inputs(v2))== [name(v1)]
+                @test name.(outputs(v1)) == [name(v2)]
+            end
 
             @testset "Add to absorbing" begin
                 v0 = inpt(3, "v0")
@@ -1098,6 +1120,17 @@
     end
 
     @testset "Vertex removal" begin
+
+        @testset "Fail noop" begin
+            v0 = inpt(3, "v0")
+            v1 = av(v0, 5, name="v1")
+            v2 = av(v1, 4, name="v2")
+
+            @test remove!(v1, RemoveStrategy(FailAlignSizeNoOp())) == false
+
+            @test name.(inputs(v2)) == [name(v1)]
+            @test name.(outputs(v1)) == [name(v2)]
+        end
 
         @testset "Remove from linear graph" begin
             v0 = inpt(3)


### PR DESCRIPTION
Mostly related to not-really-intended stuff like removing all input edges to a vertex, especially when also trying to keep all neurons when doing so.