### PR TITLE
Add ChainRulesCore

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-Cbc = "0.6, 0.7, 0.8, 0.9, 1"
+Cbc = "1.0.1"
 ChainRulesCore = "1.15"
 Functors = "0.2"
 JuMP = "0.21, 0.22, 0.23, 1"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "2.0.5"
 
 [deps]
 Cbc = "9961bab8-2fa3-5c5a-9d89-47fab24efd76"
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -12,6 +13,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 Cbc = "0.6, 0.7, 0.8, 0.9, 1"
+ChainRulesCore = "1.15"
 Functors = "0.2"
 JuMP = "0.21, 0.22, 0.23, 1"
 Reexport = "1"

--- a/src/NaiveNASlib.jl
+++ b/src/NaiveNASlib.jl
@@ -10,6 +10,9 @@ import Cbc
 import Functors
 using Functors: @functor, functor
 
+import ChainRulesCore
+import ChainRulesCore: rrule, rrule_via_ad, RuleConfig, HasReverseMode, NoTangent
+
 # Computation graph
 export CompGraph, nvertices, vertices, findvertices, inputs, outputs, name
 

--- a/src/NaiveNASlib.jl
+++ b/src/NaiveNASlib.jl
@@ -44,4 +44,6 @@ include("api/size.jl")
 include("api/Advanced.jl")
 include("api/Extend.jl")
 
+include("chainrules.jl")
+
 end # module

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -1,0 +1,27 @@
+
+const enable_explicit_gradients = Ref(false)
+
+function ChainRulesCore.rrule(config::RuleConfig{>:HasReverseMode}, ::typeof(output!), memo, v)
+    rrule_via_ad(config, output_rrule!, memo, v)
+end
+
+# Workaround for https://github.com/FluxML/Zygote.jl/issues/1111
+# and https://github.com/FluxML/Zygote.jl/issues/1243
+# Only purpose is to return NoTangent, so whole function can be deleted
+# if/when issues are resolved. Done forget to delete enable_explicit_gradients too then!
+output_rrule!(args...) = _output_rrule!(args...)
+function ChainRulesCore.rrule(config::RuleConfig{>:HasReverseMode}, ::typeof(output_rrule!), memo, v)
+    res, back = rrule_via_ad(config, _output_rrule!, memo, v)
+    return res, function (d)
+        bres = back(d)
+        return enable_explicit_gradients[] ? bres : (NoTangent(), NoTangent(), NoTangent())
+    end
+end
+
+function _output_rrule!(memo, v::AbstractVertex)
+    # rrule for get! not implemented, so we need to check the dict twice
+    v in keys(memo) && return memo[v]
+    inpt = map(iv -> output_rrule!(memo, iv),  inputs(v))
+    memo[v] = v(inpt...)
+end
+

--- a/src/compgraph.jl
+++ b/src/compgraph.jl
@@ -119,51 +119,6 @@ function _output_rrule!(memo, v::AbstractVertex)
     memo[v] = v(inpt...)
 end
 
-#= 
-import ChainRulesCore: Tangent, backing, ZeroTangent
-function ChainRulesCore.rrule(config::RuleConfig{>:HasReverseMode}, ::typeof(output!), memo, v)
-    vs = ancestors(v, collect(AbstractVertex, keys(memo)))[length(memo)+1:end]
-    res, pb = rrule_via_ad(config, output_loop!, memo, v, vs)
-
-    res, function(Δ) 
-        _, δmemo, δv, δvs = pb(Δ)
-        vgrads = Dict(zip(vs, δvs))  
-        bres = (NoTangent(), δmemo, stich_grads(v, vgrads))
-        return bres[1], bres[2], NoTangent(), NoTangent()
-    end
-end
-
-vertifytangent(v, vg) = nothing
-
-function output_loop!(memo, v, vs)
-    for vn in vs
-        vins = inputs(vn) # Types don't seem to be inferred if put in map
-        memotup = ntuple(Returns(memo), length(vins))
-        inpt = map(getindex, memotup, vins)
-        memo[vn] = vn(inpt...)
-    end
-    return memo[v]
-end
-
-stich_grads(f, ::InputVertex, args...) = ZeroTangent()
-stich_grads(v::AbstractVertex, vgrads) = stich_grads(identity, v, v, vgrads)
-function stich_grads(f, v::AbstractVertex, vkey, vgrads)
-    vkey in keys(vgrads) || return ZeroTangent()
-    mergetangent(f(vgrads[vkey]), (;base=stich_grads(g -> f(g).base, base(v), vkey, vgrads)))
-end
-
-function stich_grads(f, v::CompVertex, vkey, vgrads)
-    mygrad = f(vgrads[vkey])
-    newins = map(iv -> stich_grads(iv, vgrads), inputs(v))
-    newt = mergetangent(mygrad, (;inputs=newins))
-    return newt
-end
-
-function mergetangent(t::Tangent{P}, newelems) where P 
-    newbacking = merge(backing(t), newelems)
-    Tangent{P, typeof(newbacking)}(newbacking)
-end =#
-
 """
     nvertices(g::CompGraph)
 

--- a/src/compgraph.jl
+++ b/src/compgraph.jl
@@ -93,32 +93,6 @@ function output!(memo::AbstractDict{K,V}, v::AbstractVertex) where {K,V}
     end::V
 end
 
-
-function ChainRulesCore.rrule(config::RuleConfig{>:HasReverseMode}, ::typeof(output!), memo, v)
-    rrule_via_ad(config, output_rrule!, memo, v)
-end
-
-function output_rrule!(args...) end
-
-# Temp workaround for https://github.com/FluxML/Zygote.jl/issues/1111
-# Only purpose is to retur NoTangent, so whole function can be deleted
-# if when issue is resolved
-function ChainRulesCore.rrule(config::RuleConfig{>:HasReverseMode}, ::typeof(output_rrule!), memo, v)
-    res, back = rrule_via_ad(config, _output_rrule!, memo, v)
-    return res, function (d)
-        back(d)
-        return NoTangent(), NoTangent(), NoTangent()
-    end
-end
-
-
-function _output_rrule!(memo, v::AbstractVertex)
-    # rrule for get not implemented
-    v in keys(memo) && return memo[v]
-    inpt = map(iv -> output_rrule!(memo, iv),  inputs(v))
-    memo[v] = v(inpt...)
-end
-
 """
     nvertices(g::CompGraph)
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -8,6 +8,8 @@ Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 NaiveNASlib = "bd45eb3e-47ce-54bd-9eaf-e86c5f900853"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 Documenter = "0.27"
+Zygote = "0.6"

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -1,0 +1,134 @@
+@testset "ChainRules" begin
+
+    function with_explicit_grads(f)
+        try
+            NaiveNASlib.enable_explicit_gradients[] = true
+            f()   
+        finally
+            NaiveNASlib.enable_explicit_gradients[] = false
+        end
+    end
+
+    # We don't implement any primitive rrules in here, so we just test that the plumbing works with some popular AD
+    # Therefore ChainRulesTestUtils does not seem useful
+    @testset "Zygote" begin
+        import Zygote
+        gradient = Zygote.gradient
+
+        @testset "Simple ops" begin
+            
+            vi1,vi2 = inputvertex.("in", (1,1))
+            v1 = "add" >> vi1 + vi2
+            v2 = "mul" >> vi1 * v1
+            v3 = "div" >> v1 / v2
+
+            @test gradient(v1, 2.0, 3.0) == gradient(+, 2.0, 3.0)
+            @test gradient(v -> v(2.0, 3.0), v1) == (nothing,)
+            
+            graph = CompGraph([vi1, vi2], v3)
+            function fgraph(vi1,vi2) 
+                v1 = vi1 + vi2
+                v2 = vi1 * v1
+                v3 = v1 / v2
+            end
+
+            @test gradient(graph, 2.0, 3.0) == gradient(fgraph, 2.0, 3.0)
+            # No parameters
+            @test gradient(g -> g(2.0, 3.0), graph) == (nothing,)
+        end
+
+        @testset "With parameters" begin
+            # We have a MatMul which could be used, but it is mutable so https://github.com/FluxML/Zygote.jl/issues/1111
+            # prevents testing of gradients
+            struct ImMatMul{M<:AbstractMatrix}
+                W::M
+            end
+            ImMatMul(nin, nout) = ImMatMul(reshape(collect(1:nin*nout), nout,nin))
+            NaiveNASlib.nout(mm::ImMatMul) = size(mm.W, 1)
+            @functor ImMatMul
+            
+            (mm::ImMatMul)(x) = mm.W * x
+
+           testgrads(g::CompGraph, res, exp; seen=Base.IdSet()) = foreach(enumerate(outputs(g))) do (i, vo)
+                testgrads(vo, seen, res.outputs[i] ,exp)
+           end
+
+            function testgrads(v::AbstractVertex, seen, res, exp) 
+                v in seen && return
+                push!(seen, v)
+                _testgrads(v, seen, res, exp, Symbol(name(v)))
+            end
+
+            function _testgrads(::InputSizeVertex, seen, res, exp, name) end
+
+            function _testgrads(v::AbstractVertex, seen, res::RT, exp, name) where RT 
+                @testset "Check gradient structure for $(name) of type $(typeof(v))" begin
+                    @test hasfield(RT, :base)
+                end
+                if hasfield(RT, :base)
+                    _testgrads(base(v), seen, res.base, exp, name)
+                end
+            end
+            function _testgrads(v::CompVertex, seen, res, exp, name) 
+                @testset "Check grads for $name" begin
+                    @test res.computation == getindex(exp, name)
+                end
+                foreach(enumerate(inputs(v))) do (i, vi)
+                    testgrads(vi, seen, res.inputs[i], exp)
+                end            
+            end
+
+            function makegraphs() 
+                l1 = ImMatMul(2, 3)
+                l2 = ImMatMul(3, 3)
+                l4 = ImMatMul(6, 3)
+                
+                # Make CompGraph
+                vi = inputvertex("in", 2)
+                v1 = absorbvertex("l1", l1, vi)
+                v2 = absorbvertex("l2", l2, v1)
+                v3 = conc("v3", v1, v2; dims=1)
+                v4 = absorbvertex("l4", l4, v3) 
+                v5 = "v5" >> v1 + v4
+                v6 = conc("v6", v4, v5; dims=1)
+                graph = CompGraph(vi, v6)
+              
+                # Same function as graph but as a normal function
+                graph, function fgraph(vi)
+                    v1 = l1(vi)
+                    v2 = l2(v1)
+                    v3 = cat(v1, v2; dims=1)
+                    v4 = l4(v3) 
+                    v5 = v1 .+ v4
+                    v6 = cat(v4, v5; dims=1)
+                end          
+            end
+
+            x = reshape(collect(Float32, 1:6), 2, 3)
+            @testset "Explicit gradients" begin
+                with_explicit_grads() do
+                    graph, fgraph  = makegraphs()
+
+                    @test gradient(sum ∘ graph, x) == gradient(sum ∘ fgraph, x)
+                    res = gradient(g -> sum(g(x)), graph)
+                    exp = gradient(f -> sum(f(x)), fgraph)
+                    testgrads(graph, res..., exp...)       
+                end
+            end
+
+            @testset "Implicit gradients" begin
+                graph, fgraph  = makegraphs()
+
+                ps = getfield.(filter(c -> c isa ImMatMul, computation.(vertices(graph))), :W) |> Zygote.Params
+                res = gradient(() -> sum(graph(x)), ps)
+                exp = gradient(() -> sum(fgraph(x)), ps)
+
+                @test length(ps) == length(res) == length(exp) == 3
+
+                for p in ps
+                    @test res[p] == exp[p]
+                end
+            end
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,9 @@ include("testutil.jl")
 	
 	include("prettyprint.jl")
 
+	@info "Testing gradients"
+	include("chainrules.jl")
+
 	@info "Testing mutation"
 
 	include("mutation/vertex.jl")


### PR DESCRIPTION
Main advantage is that explicit gradients works. The `@adjoint` definition in NaiveNASflux does not propagate them, most likely because nograd is used to create a flat vector of the vertices.

It is still not 100% as gradients of outputs doesn't work (e.g. `gradient(x -> sum(graph(x)), x)`). 

Also needs testing.