### PR TITLE
Add an immutable version of CompGraph

### DIFF
--- a/src/staticgraph.jl
+++ b/src/staticgraph.jl
@@ -15,7 +15,7 @@ function ImmutableCompVertex(v::AbstractVertex, seen=IdDict())
     end
 end
 ImmutableCompVertex(v::AbstractVertex, noutputs, seen) = ImmutableCompVertex(base(v), noutputs, seen) 
-ImmutableCompVertex(v::InputVertex, noutputs, seen) = TypedInputVertex{length(seen)}()
+ImmutableCompVertex(::InputVertex, noutputs, seen) = TypedInputVertex{length(seen)}()
 function ImmutableCompVertex(v::CompVertex, noutputs, seen::IdDict) 
     ins = ImmutableCompVertex.(Tuple(inputs(v)), Ref(seen))
     comp = striptostable(v.computation)
@@ -29,12 +29,13 @@ outputs(v::ImmutableCompVertex) = v.outputs
 import NaiveNASflux: LazyMutable, MutableLayer, ActivationContribution
 
 striptostable(f) = f
-function striptostable(lm::LazyMutable) 
+## This should go in NaioveNASflux
+#= function striptostable(lm::LazyMutable) 
     NaiveNASflux.forcemutation(lm)
     striptostable(lm.mutable)
 end
 striptostable(ml::MutableLayer) = ml.layer
-striptostable(ac::ActivationContribution) = ActivationContribution(striptostable(ac.layer), ac.contribution, ac.method)
+striptostable(ac::ActivationContribution) = ActivationContribution(striptostable(ac.layer), ac.contribution, ac.method) =#
 
 struct ImmutableCompGraph{I, O}
     inputs::I

--- a/src/staticgraph.jl
+++ b/src/staticgraph.jl
@@ -1,0 +1,112 @@
+
+struct TypedInputVertex{LABEL} <: AbstractVertex end
+inputs(::TypedInputVertex) = tuple()
+
+struct ImmutableCompVertex{F, I<:Tuple, LABEL} <: AbstractVertex
+    computation::F
+    noutputs::Int
+    inputs::I
+end
+ImmutableCompVertex{LABEL}(computation::F, noutputs::Int, inputs::I) where {F, I, LABEL} = ImmutableCompVertex{F, I, LABEL}(computation, noutputs, inputs)
+ 
+function ImmutableCompVertex(v::AbstractVertex, seen=IdDict()) 
+    get!(seen, v) do
+        ImmutableCompVertex(base(v), length(outputs(v)), seen)
+    end
+end
+ImmutableCompVertex(v::AbstractVertex, noutputs, seen) = ImmutableCompVertex(base(v), noutputs, seen) 
+ImmutableCompVertex(v::InputVertex, noutputs, seen) = TypedInputVertex{length(seen)}()
+function ImmutableCompVertex(v::CompVertex, noutputs, seen::IdDict) 
+    ins = ImmutableCompVertex.(Tuple(inputs(v)), Ref(seen))
+    comp = striptostable(v.computation)
+    ImmutableCompVertex{length(seen)}(comp, noutputs, ins)
+end
+
+inputs(v::ImmutableCompVertex) = v.inputs
+outputs(v::ImmutableCompVertex) = v.outputs
+(v::ImmutableCompVertex)(x...) = v.computation(x...)
+
+import NaiveNASflux: LazyMutable, MutableLayer, ActivationContribution
+
+striptostable(f) = f
+function striptostable(lm::LazyMutable) 
+    NaiveNASflux.forcemutation(lm)
+    striptostable(lm.mutable)
+end
+striptostable(ml::MutableLayer) = ml.layer
+striptostable(ac::ActivationContribution) = ActivationContribution(striptostable(ac.layer), ac.contribution, ac.method)
+
+struct ImmutableCompGraph{I, O}
+    inputs::I
+    outputs::O
+end
+function ImmutableCompGraph(g::CompGraph)
+    seen = IdDict()
+    outs = length(outputs(g)) === 1 ? ImmutableCompVertex(only(outputs(g)), seen) : ImmutableCompVertex.(Tuple(outputs(g)), Ref(seen))
+    ins = length(inputs(g)) == 1 ? seen[only(inputs(g))] : Tuple(map(v -> seen[v]), inputs(g))
+    ImmutableCompGraph(ins, outs)
+end
+
+function (g::ImmutableCompGraph{<:TypedInputVertex, <:ImmutableCompVertex})(x)
+    evalcompgraph(g, x)
+end
+
+output_with_memo(memo, v::ImmutableCompVertex) = get_or_compute(memo, v) do mmemo, vv
+    mnew, ins = _calc_outs3(mmemo, inputs(vv))
+    out = vv(ins...)
+    vv.noutputs > 1 ? (_memoize(mnew, vv, out), out) : (mnew, out)
+end
+
+vertices(g::ImmutableCompGraph) = ancestors(g.outputs)
+Base.getindex(g::ImmutableCompGraph, args...) = getindex(vertices(g), args...)
+
+function compgraphexpr(::Type{ImmutableCompGraph{I, O}}, gname) where {I, O}
+    vexpr = vertexexpr(O, Set(), Set())
+    vname = name(O)
+    res = quote $vname = $gname.outputs end
+    append!(res.args, vexpr.args)
+    res
+end
+
+name(::Type{ImmutableCompVertex{F,T,vname}}) where {F,T,vname} = Symbol(:v, vname)
+name(::Type{TypedInputVertex{vname}}) where vname = Symbol(:v,  vname)
+
+activationname(t::Type{<:ImmutableCompVertex}) = Symbol(name(t), :_out)
+activationname(t::Type{<:TypedInputVertex})  = Symbol(name(t), :_in)
+ 
+
+function vertexexpr(t::Type{<:ImmutableCompVertex{F, T}}, seen, seeninputs) where {F, T<:Tuple{Vararg{Any}}}
+
+    vname = name(t)
+    vname in seen && return quote end
+    push!(seen, vname)
+
+    res = Expr(:block)
+    resex = res.args
+    ins = fieldtypes(T)
+    invertexnames = name.(ins)
+    invertices_to_assign = map(ivn -> ivn in seeninputs ? :_ : ivn, invertexnames)
+    if !all(ivn -> ivn === :_, invertices_to_assign)
+        push!(resex, :(($(invertices_to_assign...),) = $vname.inputs))
+    end
+    inputnames = activationname.(ins)
+    vname = name(t)
+
+    for (i, ft) in enumerate(ins)
+        push!(seeninputs, invertexnames[i])
+        ex = vertexexpr(ft, seen, seeninputs)
+        append!(resex, ex.args)
+    end
+    vout = activationname(t)
+    push!(resex, :($vout = $(vname)($(inputnames...))))
+    res
+end
+
+function vertexexpr(t::Type{<:TypedInputVertex}, seen, seeninputs) 
+    push!(seen, name(t))
+    return quote end
+end
+
+@generated function evalcompgraph(g::ImmutableCompGraph{I}, v0_in) where I <: TypedInputVertex
+    compgraphexpr(g, :g)
+end


### PR DESCRIPTION
Basically an alternative to #102 which is a bit less attractive since it requires creating a completely new structure.

Current version does not have tests yet but is tested with a couple of random networks from NaiveGAflux. Unfortunately (or perhaps fortunately) the performance with Zygote seems to be way worse than #102. 

This is a bit surprising however since the generated function completely unrolls the graph, so maybe it is worth revisiting. For example: 

```julia
## gg is a CompGraph generated by NaiveGAflux
gs = ImmutableCompGraph(gg)
compgraphexpr(typeof(gs), :g) = quote
    v15 = g.outputs
    (v14,) = v15.inputs
    (v13,) = v14.inputs
    (v12,) = v13.inputs
    (v11,) = v12.inputs
    (v7, v10) = v11.inputs
    (v6,) = v7.inputs
    (v5,) = v6.inputs
    (v4,) = v5.inputs
    (v0, v3) = v4.inputs
    (v2,) = v3.inputs
    (v1,) = v2.inputs
    v1_out = v1(v0_in)
    v2_out = v2(v1_out)
    v3_out = v3(v2_out)
    v4_out = v4(v0_in, v3_out)
    v5_out = v5(v4_out)
    v6_out = v6(v5_out)
    v7_out = v7(v6_out)
    (v9,) = v10.inputs
    (v8,) = v9.inputs
    v8_out = v8(v5_out)
    v9_out = v9(v8_out)
    v10_out = v10(v9_out)
    v11_out = v11(v7_out, v10_out)
    v12_out = v12(v11_out)
    v13_out = v13(v12_out)
    v14_out = v14(v13_out)
    v15_out = v15(v14_out)
end
```
Main "trick" to make it possible to do the above in type domain is to add an `isbits` identifier in the vertex type. Current version uses an `Int` which is just a running number of how many `ImmutableCompVertex` has been created (per call to `ImmutableCompGraph`).

Other options tried but which didn't give sufficient performance was to index the inputs instead of destructuring, e.g `v7 = v11.inputs[1]` and `v10 = v11.inputs[2]` instead of `(v7, v10) = v11.inputs`.

Also tried:
* [RuntimeGeneratedFunctions](https://github.com/SciML/RuntimeGeneratedFunctions.jl)
* Storing a tuple of vertices in topological order and use that to extract the v0, v1 etc variables. A bit worse performance iirc.
* Adding a `function f(g, v0_in)` expression on top of the above and just evaling it on the top level. The fact that this doesn't improve performance is probably an indication that a different type of expression is needed. Perhaps Zygote doesn't like to compile long functions?
* All of the above except the expression is changed to work on `CompGraph` instead of `ImmutableCompGraph`. This was significantly worse for all versions.
