### PR TITLE
Add graphsummary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,13 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+        if: matrix.os == 'ubuntu-latest'
+      - uses: codecov/codecov-action@v4
+        if: matrix.os == 'ubuntu-latest'
         with:
           file: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false  # CI don't fail if Codecov is down. Maybe it should...
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: macOS-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest

--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,7 @@
 using Documenter, Literate, NaiveNASlib, NaiveNASlib.Advanced, NaiveNASlib.Extend
 
+NaiveNASlib.GRAPHSUMMARY_USE_HIGHLIGHTS[] = false
+
 const nndir = joinpath(dirname(pathof(NaiveNASlib)), "..")
 
 function literate_example(sourcefile; rootdir=nndir, sourcedir = "test/examples", destdir="docs/src/examples", kwargs...)
@@ -64,3 +66,7 @@ if get(ENV, "CI", nothing) == "true"
         push_preview=true
     )
 end
+
+NaiveNASlib.GRAPHSUMMARY_USE_HIGHLIGHTS[] = true
+
+nothing # Just so that include("make.jl") does not return anything

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,15 +2,15 @@ using Documenter, Literate, NaiveNASlib, NaiveNASlib.Advanced, NaiveNASlib.Exten
 
 const nndir = joinpath(dirname(pathof(NaiveNASlib)), "..")
 
-function literate_example(sourcefile; rootdir=nndir, sourcedir = "test/examples", destdir="docs/src/examples")
-    fullpath = Literate.markdown(joinpath(rootdir, sourcedir, sourcefile), joinpath(rootdir, destdir); flavor=Literate.DocumenterFlavor(), mdstrings=true, codefence="````julia" => "````")
+function literate_example(sourcefile; rootdir=nndir, sourcedir = "test/examples", destdir="docs/src/examples", kwargs...)
+    fullpath = Literate.markdown(joinpath(rootdir, sourcedir, sourcefile), joinpath(rootdir, destdir); flavor=Literate.DocumenterFlavor(), mdstrings=true, kwargs...)
     dirs = splitpath(fullpath)
     srcind = findfirst(==("src"), dirs)
     joinpath(dirs[srcind+1:end]...)
 end
 
 quicktutorial = literate_example("quicktutorial.jl")
-advancedtutorial = literate_example("advancedtutorial.jl")
+advancedtutorial = literate_example("advancedtutorial.jl"; codefence="````julia" => "````")
 
 makedocs(   sitename="NaiveNASlib",
             root = joinpath(nndir, "docs"), 

--- a/docs/src/reference/simple/graph.md
+++ b/docs/src/reference/simple/graph.md
@@ -7,4 +7,5 @@ outputs(::CompGraph)
 vertices
 nvertices
 findvertices
+graphsummary
 ```

--- a/src/NaiveNASlib.jl
+++ b/src/NaiveNASlib.jl
@@ -11,9 +11,10 @@ using JuMP: @variable, @constraint, @objective, @expression, MOI, MOI.INFEASIBLE
 import HiGHS
 import Functors
 using Functors: @functor, functor
+import PrettyTables
 
 # Computation graph
-export CompGraph, nvertices, vertices, findvertices, inputs, outputs, name
+export CompGraph, nvertices, vertices, findvertices, inputs, outputs, name, graphsummary
 
 # Vertex size operations
 export nin, nout, Δnin!, Δnout!, Δsize!, relaxed

--- a/src/api/Extend.jl
+++ b/src/api/Extend.jl
@@ -16,6 +16,6 @@ using Reexport: @reexport
 @reexport using ..NaiveNASlib: AbstractAlignSizeStrategy
 @reexport using ..NaiveNASlib: AbstractConnectStrategy
 
-@reexport using ..NaiveNASlib: base, parselect, vertex
+@reexport using ..NaiveNASlib: base, parselect, vertex, op
 
 end

--- a/src/compgraph.jl
+++ b/src/compgraph.jl
@@ -208,7 +208,7 @@ julia> vertices(graph)
 vertices(g::CompGraph{<:Any, <:Tuple}) = unique(mapfoldl(ancestors, vcat, outputs(g)))
 vertices(g::CompGraph{<:Any, <:AbstractVertex}) = ancestors(g.outputs)
 
-## Non-public stuff to compute the CompGraph in a Zygote (and hopefully generally reverse-AD friendly) manner
+## Non-public stuff to compute the CompGraph in a Zygote (and hopefully generally reverse-AD) friendly manner
 
 compute_graph(memo, v::AbstractVertex) = last(output_with_memo(memo, v))
 compute_graph(memo, vs::Tuple) = last(_calc_outs(memo, vs))

--- a/src/mutation/vertex.jl
+++ b/src/mutation/vertex.jl
@@ -6,6 +6,8 @@ Return the vertex wrapped in `v` (if any).
 """
 function base(::AbstractVertex) end
 
+op(v::AbstractVertex) = op(base(v))
+
 """
     OutputsVertex
 

--- a/src/prettyprint.jl
+++ b/src/prettyprint.jl
@@ -1,3 +1,114 @@
+Base.show(g::CompGraph, args...; kwargs...) = show(stdout, g, args...; kwargs...)
+function Base.show(io::IO, g::CompGraph, args...; kwargs...) 
+    # Don't print the summary table if we are printing some iterable (as indicated by presence of :SHOWN_SET)
+    haskey(io, :SHOWN_SET) && return print(io, "CompGraph(", nvertices(g)," vertices)")
+    graphsummary(io, g, args...; title="CompGraph with graphsummary:", kwargs...)
+end
+
+"""
+    graphsummary([io], graph, extracolumns...; [inputhl], [outputhl], kwargs...)
+
+Prints a summary table of `graph` to `io` using `PrettyTables.pretty_table`.
+
+Extra columns can be added to the table by providing any number of `extracolumns` which can be one of the following:
+* a function (or any callable object) which takes a vertex as input and returns the column content
+* a `Pair` where the first element is the column name and the other element is what previous bullet describes
+
+The keyword arguments `inputhl` (default `crayon"fg:black bg:249"`) and `outputhl` (default `inputhl`) can be used
+to set the highlighting of the inputs and outputs to `graph` respectively. If set to `nothing` no special highlighting
+will be used.
+
+All other keyword arguments are forwarded to `PrettyTables.pretty_table`. Note that this allows for overriding the
+default formatting, alignment and highlighting.
+
+!!! warning "API Stability" 
+    While this function is part of the public API for natural reasons, the exact shape of its output shall not be considered stable.
+
+    `Base.show` for `CompGraph`s just forwards all arguments and keyword arguments to this method. This might change in the future.
+
+### Examples
+```jldoctest
+julia> using NaiveNASlib
+
+julia> g = let 
+            v1 = "v1" >> inputvertex("in1", 1) + inputvertex("in2", 1)
+            v2 = invariantvertex("v2", sin, v1)
+            v3 = conc("v3", v1, v2; dims=1) 
+            CompGraph(inputs(v1), v3)
+        end;
+
+julia> graphsummary(g)
+┌────────────────┬───────────┬────────────────┬───────────────────┐
+│ Graph Position │ Vertex Nr │ Input Vertices │ Op                │
+├────────────────┼───────────┼────────────────┼───────────────────┤
+│ Input          │ 1         │                │                   │
+│ Input          │ 2         │                │                   │
+│ Hidden         │ 3         │ 1,2            │ + (element wise)  │
+│ Hidden         │ 4         │ 3              │ sin               │
+│ Output         │ 5         │ 3,4            │ cat(x..., dims=1) │
+└────────────────┴───────────┴────────────────┴───────────────────┘
+
+julia> graphsummary(g, name, "input sizes" => nin, "output sizes" => nout)
+┌────────────────┬───────────┬────────────────┬───────────────────┬──────┬─────────────┬──────────────┐
+│ Graph Position │ Vertex Nr │ Input Vertices │ Op                │ Name │ input sizes │ output sizes │
+├────────────────┼───────────┼────────────────┼───────────────────┼──────┼─────────────┼──────────────┤
+│ Input          │ 1         │                │                   │ in1  │             │ 1            │
+│ Input          │ 2         │                │                   │ in2  │             │ 1            │
+│ Hidden         │ 3         │ 1,2            │ + (element wise)  │ v1   │ 1,1         │ 1            │
+│ Hidden         │ 4         │ 3              │ sin               │ v2   │ 1           │ 1            │
+│ Output         │ 5         │ 3,4            │ cat(x..., dims=1) │ v3   │ 1,1         │ 2            │
+└────────────────┴───────────┴────────────────┴───────────────────┴──────┴─────────────┴──────────────┘
+```
+"""
+graphsummary(g::CompGraph, extracolumns...; kwargs...) = graphsummary(stdout, g, extracolumns...; kwargs...)
+function graphsummary(io, g::CompGraph, extracolumns...; 
+                        inputhl=PrettyTables.crayon"fg:black bg:249", 
+                        outputhl=inputhl,
+                        kwargs...)
+    t = summarytable(g, extracolumns...)
+    
+    # Default formatting
+    arraytostr = (x, args...) -> x isa AbstractVector ? join(x, ",") : isnothing(x) ? "" : x
+    rowhighligts = PrettyTables.Highlighter(Returns(true), function(h, x, i, j)
+        !isnothing(inputhl) &&  i <= length(inputs(g)) && return inputhl
+        !isnothing(outputhl) && i > length(t[1]) - length(outputs(g)) && return outputhl
+        length(t[1]) > 7 && iseven(i - isnothing(inputhl) * length(inputs(g))) && return PrettyTables.crayon"fg:white bold bg:dark_gray"
+        PrettyTables.crayon"default"
+    end)
+
+    PrettyTables.pretty_table(io, t; 
+                        show_subheader=false, 
+                        formatters=arraytostr, 
+                        highlighters = rowhighligts, 
+                        alignment = :l,
+                        kwargs...)
+end
+
+function summarytable(g::CompGraph, extracols...)
+    vs = vertices(g)
+
+    inds = sort(collect(eachindex(vs)); by = function(i)
+        vs[i] in inputs(g) && return i - length(vs)
+        vs[i] in outputs(g) && return i + length(vs)
+        i
+    end)
+
+    vs_roworder = vs[inds] 
+
+    NamedTuple((
+        Symbol("Graph Position") => map(v -> v in inputs(g) ? :Input : v in outputs(g) ? :Output : :Hidden, vs_roworder),
+        Symbol("Vertex Nr") => inds,
+        Symbol("Input Vertices") => map(v -> something.(indexin(inputs(v), vs), -1), vs_roworder),
+        :Op => op.(vs_roworder),
+        map(c -> _createextracol(c, vs_roworder), extracols)...
+    ))
+end
+
+_createextracol(f, vs) = Symbol(uppercasefirst(string(f))) => f.(vs)
+_createextracol(p::Pair, vs) = Symbol(first(p)) => last(p).(vs) 
+
+## Other stuff related to printing long arrays of numbers assuming patterns which often happen
+## when mutating, typically long streaks of -1 and ascending integers.
 
 compressed_string(x) = string(x)
 struct RangeState

--- a/src/prettyprint.jl
+++ b/src/prettyprint.jl
@@ -72,7 +72,10 @@ function graphsummary(io, g::CompGraph, extracolumns...;
     rowhighligts = PrettyTables.Highlighter(Returns(true), function(h, x, i, j)
         !isnothing(inputhl) &&  i <= length(inputs(g)) && return inputhl
         !isnothing(outputhl) && i > length(t[1]) - length(outputs(g)) && return outputhl
-        length(t[1]) > 7 && iseven(i - isnothing(inputhl) * length(inputs(g))) && return PrettyTables.crayon"fg:white bold bg:dark_gray"
+        # Kinda random to enable highlights on even rows if we have more than seven rows
+        # If we do use it, we want it to start with default for the first hidden layer/vertex regardless of how 
+        # many input vertices there are (assuming we use different formatting for input vertices).
+        length(t[1]) > 7 && iseven(i - !isnothing(inputhl) * length(inputs(g))) && return PrettyTables.crayon"fg:white bold bg:dark_gray"
         PrettyTables.crayon"default"
     end)
 

--- a/src/prettyprint.jl
+++ b/src/prettyprint.jl
@@ -62,7 +62,7 @@ julia> graphsummary(g, name, "input sizes" => nin, "output sizes" => nout)
 """
 graphsummary(g::CompGraph, extracolumns...; kwargs...) = graphsummary(stdout, g, extracolumns...; kwargs...)
 function graphsummary(io, g::CompGraph, extracolumns...; 
-                        inputhl=PrettyTables.crayon"fg:black bg:249", 
+                        inputhl=PrettyTables.crayon"fg:black bg:white", 
                         outputhl=inputhl,
                         kwargs...)
     t = summarytable(g, extracolumns...)

--- a/src/vertex.jl
+++ b/src/vertex.jl
@@ -146,3 +146,7 @@ Note that names in a graph don't have to be unique.
 """
 name(v::AbstractVertex) = string(nameof(typeof(v)))
 name(v::InputVertex) = v.name
+
+op(::InputVertex) = nothing
+op(v::CompVertex) = op(v.computation)
+op(f) = f

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -11,5 +11,5 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
-Documenter = "0.27"
+Documenter = "1"
 Zygote = "0.6"

--- a/test/examples/advancedtutorial.jl
+++ b/test/examples/advancedtutorial.jl
@@ -211,7 +211,7 @@ end
 (::RenameWalk)(recurse, x) = Functors.DefaultWalk()(recurse, x) 
 
 # I must admit that thinking about what this does makes me a bit dizzy...
-namedgraph = Functors.fmap(walk, identity, graph)
+namedgraph = Functors.execute(walk, graph)
 
 @test name.(vertices(namedgraph)) == ["in changed", "layer1", "layer2"]
 @test graph(ones(2, 1)) == namedgraph(ones(2,1))

--- a/test/mutation/structure.jl
+++ b/test/mutation/structure.jl
@@ -621,8 +621,8 @@ import JuMP
                 v4 = iv(v1,v2, name = "v4")
                 v5 = av(v4, 3, name="v5")
 
-                # Use utility 0 to remove an index so we can see that the utility function has any effect
-                create_edge!(v3, v4, strategy=PostAlign(WithUtilityFun(v -> 0:nout(v)-1 , AlignNinToNout())))
+                # Use utility -10 to remove an index so we can see that the utility function has any effect
+                create_edge!(v3, v4, strategy=PostAlign(WithUtilityFun(v -> v === v3 ? vcat(-10, 2:nout(v)) : 1, AlignNinToNout())))
 
                 @test inputs(v4) == [v1, v2, v3]
                 @test nin(v4) == nout.([v1, v2, v3]) == [4,4,4]

--- a/test/prettyprint.jl
+++ b/test/prettyprint.jl
@@ -1,3 +1,86 @@
+@testset "CompGraph" begin
+
+
+    av(name, in, outsize) = absorbvertex(name, MatMul(nout(in), outsize), in)
+
+    function testgraph() 
+        iv1 = inputvertex("iv1", 1)
+        iv2 = inputvertex("iv2", 2)
+
+        v1 = av("v1", iv1, 3)
+        v2 = av("v2", v1, 4)
+
+        v3 = av("v3", iv2, 5)
+        v4 = av("v4", v1, 5)
+
+        v5 = "v5" >> v3 + v4
+
+        v6 = conc("v6", v2, v3; dims=1)
+
+        CompGraph([iv1, iv2], [v6, v5])
+    end
+
+    @testset "summarytable" begin
+        import NaiveNASlib: summarytable
+
+        g = testgraph()
+        t = summarytable(g, "vname"=>name, nin, nout)
+
+        vs = vertices(g)
+        @testset "Check vertex $i" for i in eachindex(t[1]) 
+            v = vs[t[2][i]]
+            @test name(v) == t.vname[i]
+            @test name.(inputs(v)) == name.(vs[t[3][i]])
+            @test nin(v) == t.Nin[i]
+            @test nout(v) == t.Nout[i]
+        end
+    end
+
+    @testset "pretty print full" begin
+        g = testgraph()
+        str = sprint((args...) -> show(args..., "vname"=>name, nin, nout; highlighters=tuple()), g)
+
+        expnames = name.(vertices(g))
+        innames = name.(inputs(g))
+        outnames = name.(outputs(g))
+        hnames = setdiff(expnames, innames, outnames)
+
+        foundnames = String[]
+
+        for row in split(str, '\n')
+            if contains(row, "Input  ")
+                m = match(Regex(string('(', join(innames, '|'), ')')), row)
+                @test !isnothing(m)
+                append!(foundnames, m.captures)
+            end
+
+            if contains(row, "Hidden")
+                m = match(Regex(string('(', join(hnames, '|'), ')')), row)
+                @test !isnothing(m)
+                append!(foundnames, m.captures)
+            end
+
+            if contains(row, "Output")
+                m = match(Regex(string('(', join(outnames, '|'), ')')), row)
+                @test !isnothing(m)
+                append!(foundnames, m.captures)
+            end
+        end
+
+        @test sort(expnames) == sort(foundnames)
+    end
+
+    @testset "pretty print array" begin
+        g = testgraph()
+
+        str = sprint(show, CompGraph[g])
+
+        @test str == "CompGraph[CompGraph($(nvertices(g)) vertices)]"
+
+    end
+end
+
+
 @testset "Compressed array string" begin
     @test NaiveNASlib.compressed_string([1,2,3,4]) == "[1, 2, 3, 4]"
     @test NaiveNASlib.compressed_string(1:23) == "[1,…, 23]"

--- a/test/prettyprint.jl
+++ b/test/prettyprint.jl
@@ -36,9 +36,9 @@
         end
     end
 
-    @testset "pretty print full" begin
+    @testset "graphsummary" begin
         g = testgraph()
-        str = sprint((args...) -> show(args..., "vname"=>name, nin, nout; highlighters=tuple()), g)
+        str = sprint((args...) -> graphsummary(args..., "vname"=>name, nin, nout; highlighters=tuple()), g)
 
         expnames = name.(vertices(g))
         innames = name.(inputs(g))
@@ -76,7 +76,6 @@
         str = sprint(show, CompGraph[g])
 
         @test str == "CompGraph[CompGraph($(nvertices(g)) vertices)]"
-
     end
 end
 

--- a/test/prettyprint.jl
+++ b/test/prettyprint.jl
@@ -36,6 +36,12 @@
         end
     end
 
+    @testset "show" begin
+        g = testgraph()
+        str = sprint((args...) -> show(args...), g)
+        @test length(split(str, '\n')) == nvertices(g)+6        
+    end
+
     @testset "graphsummary" begin
         g = testgraph()
         str = sprint((args...) -> graphsummary(args..., "vname"=>name, nin, nout; highlighters=tuple()), g)


### PR DESCRIPTION
graphsummary uses PrettyTables to print a nice (?) summary of a `CompGraph`.

I also decided to make this the default `show` method since `CompGraph`s currently display horribly (as in REPL-hanging horribly). 

I don't love this though since the output is quite far from the recommendation for `show` to be parseable Julia code (the current `show` does not fulfill this either afaik, at least not in the sense that running it is guaranteed to result in the same object).